### PR TITLE
Update Nokogiri and Activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     easy_sax (0.1.3)
-      activesupport (~> 7.0.4.1)
-      nokogiri (~> 1.13.9)
+      activesupport (~> 7.0.4.3)
+      nokogiri (~> 1.13.10)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,41 @@
 PATH
   remote: .
   specs:
-    easy_sax (0.1.2)
-      activesupport (>= 1.6)
-      nokogiri (>= 1.13.6)
+    easy_sax (0.1.3)
+      activesupport (~> 7.0.4.1)
+      nokogiri (~> 1.13.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
-    i18n (1.10.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.4)
-    nokogiri (1.13.6-arm64-darwin)
+    minitest (5.18.1)
+    nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.6.0)
+    racc (1.7.1)
     rake (13.0.6)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.13.9"
-  spec.add_dependency "activesupport", "~> 7.0.4.1"
+  spec.add_dependency "nokogiri", "~> 1.13.10"
+  spec.add_dependency "activesupport", "~> 7.0.4.3"
 
   spec.add_development_dependency "bundler", "~> 2.2.24"
   spec.add_development_dependency "rake"

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", ">= 1.13.6"
-  spec.add_dependency "activesupport", ">= 1.6"
+  spec.add_dependency "nokogiri", "~> 1.13.9"
+  spec.add_dependency "activesupport", "~> 7.0.4.1"
 
   spec.add_development_dependency "bundler", "~> 2.2.24"
   spec.add_development_dependency "rake"

--- a/lib/easy_sax/version.rb
+++ b/lib/easy_sax/version.rb
@@ -1,3 +1,3 @@
 module EasySax
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Updates Nokogiri and Activesupport to close dependabot alerts.

- Updates Nokogiri from 1.13.6 to 1.13.10
- Updates Activesupport from 7.0.3 to 7.0.4.3

Dependencies should also be updated:
  - [Nokogiri dependencies](https://rubygems.org/gems/nokogiri/versions/1.13.10/dependencies)
  - [Activesupport dependencies](https://rubygems.org/gems/activesupport/versions/7.0.4.3/dependencies)