### PR TITLE
Fix Github Actions workflow and prepare the gem for Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-gem-use-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}
       - name: Bundle install
         run: |
-          gem install bundler:2.2.24
+          gem install bundler:2.3.6
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup ruby ${{ matrix.ruby_version }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Setup cache key and directory for gems cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-use-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [ '2.7' ]
+        ruby_version: [ '2.7', '3.1' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easy_sax (0.1.3)
+    easy_sax (0.1.4)
       activesupport (~> 7.0.4.3)
       nokogiri (~> 1.13.10)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,11 +40,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 2.2.24)
+  bundler (~> 2.3.6)
   easy_sax!
   minitest (~> 5.0)
   pry
   rake
 
 BUNDLED WITH
-   2.2.33
+   2.3.6

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "~> 1.13.10"
   spec.add_dependency "activesupport", "~> 7.0.4.3"
 
-  spec.add_development_dependency "bundler", "~> 2.2.24"
+  spec.add_development_dependency "bundler", "~> 2.3.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry"

--- a/lib/easy_sax/version.rb
+++ b/lib/easy_sax/version.rb
@@ -1,3 +1,3 @@
 module EasySax
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
We updated deprecated actions so our tests can run and we also made the workflow to run against Ruby 3.1.