### PR TITLE
Update Nokogiri and Activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    easy_sax (0.1.5)
+    easy_sax (0.1.4)
       activesupport (~> 7.0.4.3)
-      nokogiri (~> 1.15.4)
+      nokogiri (~> 1.13.10)
 
 GEM
   remote: https://rubygems.org/
@@ -19,11 +19,11 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.18.1)
-    nokogiri (1.15.4-arm64-darwin)
+    nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-darwin)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     easy_sax (0.1.4)
-      activesupport (~> 7.0.4.3)
+      activesupport (~> 7.0.8)
       nokogiri (~> 1.15.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -18,7 +18,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.18.1)
+    minitest (5.20.0)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     easy_sax (0.1.4)
       activesupport (~> 7.0.4.3)
-      nokogiri (~> 1.13.10)
+      nokogiri (~> 1.15.4)
 
 GEM
   remote: https://rubygems.org/
@@ -19,11 +19,11 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.18.1)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    easy_sax (0.1.4)
+    easy_sax (0.1.5)
       activesupport (~> 7.0.4.3)
-      nokogiri (~> 1.13.10)
+      nokogiri (~> 1.15.4)
 
 GEM
   remote: https://rubygems.org/
@@ -19,11 +19,11 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.18.1)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", "~> 1.15.4"
-  spec.add_dependency "activesupport", "~> 7.0.4.3"
+  spec.add_dependency "activesupport", "~> 7.0.8"
 
   spec.add_development_dependency "bundler", "~> 2.3.6"
   spec.add_development_dependency "rake"

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.15.4"
+  spec.add_dependency "nokogiri", "~> 1.13.10"
   spec.add_dependency "activesupport", "~> 7.0.4.3"
 
   spec.add_development_dependency "bundler", "~> 2.3.6"

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.13.10"
+  spec.add_dependency "nokogiri", "~> 1.15.4"
   spec.add_dependency "activesupport", "~> 7.0.4.3"
 
   spec.add_development_dependency "bundler", "~> 2.3.6"

--- a/lib/easy_sax/version.rb
+++ b/lib/easy_sax/version.rb
@@ -1,3 +1,3 @@
 module EasySax
-  VERSION = "0.1.5"
+  VERSION = "0.1.4"
 end

--- a/lib/easy_sax/version.rb
+++ b/lib/easy_sax/version.rb
@@ -1,3 +1,3 @@
 module EasySax
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
We're updating Nokogiri and Activesupport to fix Dependabot alerts

- Updates Nokogiri from 1.13.10 to 1.15.4
- Updates Activesupport from 7.0.4.3 to 7.0.8
  - Updates minitest dependency from 5.18.1 to 5.20.0