### PR TITLE
Update/bump nokogiri to 1.18.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Setup cache key and directory for gems cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-use-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,33 +3,33 @@ PATH
   specs:
     easy_sax (0.2.0)
       activesupport (~> 7.0.8)
-      nokogiri (~> 1.16.2)
+      nokogiri (~> 1.18.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8)
+    activesupport (7.0.8.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
-    i18n (1.14.1)
+    concurrent-ruby (1.3.5)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    method_source (1.0.0)
-    minitest (5.20.0)
-    nokogiri (1.16.2-arm64-darwin)
+    method_source (1.1.0)
+    minitest (5.25.4)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    pry (0.14.1)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.7.3)
-    rake (13.0.6)
+    racc (1.8.1)
+    rake (13.2.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
@@ -37,6 +37,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-linux
 

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.16.2"
+  spec.add_dependency "nokogiri", "~> 1.18.3"
   spec.add_dependency "activesupport", "~> 7.0.8"
 
   spec.add_development_dependency "bundler", "~> 2.3.6"

--- a/lib/easy_sax/version.rb
+++ b/lib/easy_sax/version.rb
@@ -1,3 +1,3 @@
 module EasySax
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
### What does this PR do?

* Bumps nokogiri to 1.18.3
* Bumps easy sax version to 0.2.1
* Bumps actions/cache@v4 for github actions