### PR TITLE
[sc-65405] Update activesupport to 7.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,30 +2,48 @@ PATH
   remote: .
   specs:
     easy_sax (0.3.0)
-      activesupport (~> 7.0.8)
+      activesupport (>= 7.2.3.1, < 8.0)
       nokogiri (~> 1.19.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8.7)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.3.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    drb (2.2.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    logger (1.7.0)
     method_source (1.1.0)
-    minitest (5.25.4)
+    minitest (5.27.0)
     nokogiri (1.19.1-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     racc (1.8.1)
     rake (13.2.1)
+    securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/easy_sax.gemspec
+++ b/easy_sax.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", "~> 1.19.1"
-  spec.add_dependency "activesupport", "~> 7.0.8"
+  spec.add_dependency "activesupport", ">= 7.2.3.1", "< 8.0"
 
   spec.add_development_dependency "bundler", "~> 2.3.6"
   spec.add_development_dependency "rake"

--- a/lib/easy_sax/version.rb
+++ b/lib/easy_sax/version.rb
@@ -1,3 +1,3 @@
 module EasySax
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
### Summary
Raises the minimum supported `activesupport` version in `easy_sax` to the patched 7.2.3.1 release and refreshes the lockfile.

### Context
Shortcut story `sc-65405` tracks a Dependabot security alert for the direct `activesupport` dependency declared by this gem.

### Solution
Updated the gemspec constraint to `>= 7.2.3.1, < 8.0` and regenerated `Gemfile.lock` so the test suite runs against the secure version.